### PR TITLE
Fixed data lost during compression and adds an small refactor of rspec.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.1
+
+* Fixes data loss that happen for each even of each new round after the
+  first one.
+
 # 0.2.0
 
 * Refactoring the Json and Timestamp usage

--- a/lib/logstash/codecs/compress_spooler.rb
+++ b/lib/logstash/codecs/compress_spooler.rb
@@ -21,13 +21,13 @@ class LogStash::Codecs::CompressSpooler < LogStash::Codecs::Base
   end # def decode
 
   def encode(event)
+    # use normalize to make sure returned Hash is pure Ruby for
+    # MessagePack#pack which relies on pure Ruby object recognition
+    @buffer << LogStash::Util.normalize(event.to_hash).merge(LogStash::Event::TIMESTAMP => event.timestamp.to_iso8601)
+    # If necessary, we flush the buffer and get the data compressed
     if @buffer.length >= @spool_size
       @on_event.call(compress(@buffer, @compress_level))
       @buffer.clear
-    else
-      # use normalize to make sure returned Hash is pure Ruby for
-      # MessagePack#pack which relies on pure Ruby object recognition
-      @buffer << LogStash::Util.normalize(event.to_hash).merge(LogStash::Event::TIMESTAMP => event.timestamp.to_iso8601)
     end
   end # def encode
 

--- a/logstash-codec-compress_spooler.gemspec
+++ b/logstash-codec-compress_spooler.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-compress_spooler'
-  s.version         = '0.2.0'
+  s.version         = '0.2.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "codec that processes compressed spooled data"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/codecs/compress_spooler_spec.rb
+++ b/spec/codecs/compress_spooler_spec.rb
@@ -98,8 +98,6 @@ describe LogStash::Codecs::CompressSpooler do
 
       before(:each) do
         codec.on_event{|data| results << data}
-        # spool_size is one so encode twice to trigger encoding on the 2nd one
-        codec.encode(event)
         codec.encode(event)
       end
 
@@ -112,8 +110,6 @@ describe LogStash::Codecs::CompressSpooler do
 
       before(:each) do
         codec.on_event{|data| results << data}
-        # spool_size is one so encode twice to trigger encoding on the 2nd one
-        codec.encode(event)
         codec.encode(event)
       end
       include_examples "Encoding data"


### PR DESCRIPTION
After updating the codebase of this plugins with the merge of #1 fixing there also the timestamp issue reported at #2, this PR updates #4 to get rid of the data loss during the first even of each new buch of events being compressed.

During this changes it add's an small refactor on the specs side.

Fixes #3 
