### PR TITLE
Minimum flush interval added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.gem
 Gemfile.lock
 .bundle
+*.swp

--- a/lib/logstash/codecs/compress_spooler.rb
+++ b/lib/logstash/codecs/compress_spooler.rb
@@ -31,7 +31,7 @@ class LogStash::Codecs::CompressSpooler < LogStash::Codecs::Base
     # MessagePack#pack which relies on pure Ruby object recognition
     @buffer << LogStash::Util.normalize(event.to_hash).merge(LogStash::Event::TIMESTAMP => event.timestamp.to_iso8601)
     # If necessary, we flush the buffer and get the data compressed
-    if @buffer.length >= @spool_size || (@min_flush_time > 0 && (@last_flush + @min_flush_time < Time.now.to_i))
+    if @buffer.length >= @spool_size || time_to_flush?
       @on_event.call(compress(@buffer, @compress_level))
       @buffer.clear
       @last_flush = Time.now.to_i
@@ -60,4 +60,9 @@ class LogStash::Codecs::CompressSpooler < LogStash::Codecs::Base
     z.close
     result
   end
+
+  def time_to_flush?
+    return @min_flush_time > 0 && (@last_flush + @min_flush_time < Time.now.to_i)
+  end
+
 end # class LogStash::Codecs::CompressSpooler

--- a/lib/logstash/codecs/compress_spooler.rb
+++ b/lib/logstash/codecs/compress_spooler.rb
@@ -6,12 +6,18 @@ class LogStash::Codecs::CompressSpooler < LogStash::Codecs::Base
   config :spool_size, :validate => :number, :default => 50
   config :compress_level, :validate => :number, :default => 6
 
+  # The amount of time in seconds since last flush before a flush is forced,
+  # on the next event.
+  # Values smaller than 0 disables time based flushing.
+  config :min_flush_time, :validate => :number, :default => 0
+
   public
 
   def register
     require "msgpack"
     require "zlib"
     @buffer = []
+    @last_flush = Time.now.to_i
   end
 
   def decode(data)
@@ -25,9 +31,10 @@ class LogStash::Codecs::CompressSpooler < LogStash::Codecs::Base
     # MessagePack#pack which relies on pure Ruby object recognition
     @buffer << LogStash::Util.normalize(event.to_hash).merge(LogStash::Event::TIMESTAMP => event.timestamp.to_iso8601)
     # If necessary, we flush the buffer and get the data compressed
-    if @buffer.length >= @spool_size
+    if @buffer.length >= @spool_size || (@min_flush_time > 0 && (@last_flush + @min_flush_time < Time.now.to_i))
       @on_event.call(compress(@buffer, @compress_level))
       @buffer.clear
+      @last_flush = Time.now.to_i
     end
   end # def encode
 

--- a/spec/codecs/compress_spooler_spec.rb
+++ b/spec/codecs/compress_spooler_spec.rb
@@ -143,6 +143,33 @@ describe LogStash::Codecs::CompressSpooler do
           expect(buffer.size).to eq(2)
         end
       end
+
+      context "message spooling if min flush time is set" do
+        let(:spool_size) { 10 }
+        min_flush_time = 2
+        let(:min_flush_time) { min_flush_time }
+        subject(:codec) { LogStash::Codecs::CompressSpooler.new("spool_size" => spool_size, "min_flush_time" => min_flush_time) }
+        let(:data) { {"foo" => "bar"} }
+
+        it "dont'f flush the initial messages, but flush after min flush time on next message" do
+          codec.encode(event)
+          buffer= codec.instance_variable_get(:@buffer)
+          expect(buffer.size).to eq(1)
+
+          codec.encode(event)
+          buffer= codec.instance_variable_get(:@buffer)
+          expect(buffer.size).to eq(2)
+
+          sleep(min_flush_time + 1)
+
+          buffer= codec.instance_variable_get(:@buffer)
+          expect(buffer.size).to eq(2)
+
+          codec.encode(event)
+          buffer= codec.instance_variable_get(:@buffer)
+          expect(buffer.size).to eq(0)
+        end
+      end
     end
   end
 end

--- a/spec/codecs/compress_spooler_spec.rb
+++ b/spec/codecs/compress_spooler_spec.rb
@@ -146,9 +146,9 @@ describe LogStash::Codecs::CompressSpooler do
 
       context "message spooling if min flush time is set" do
         let(:spool_size) { 10 }
-        min_flush_time = 2
-        let(:min_flush_time) { min_flush_time }
-        subject(:codec) { LogStash::Codecs::CompressSpooler.new("spool_size" => spool_size, "min_flush_time" => min_flush_time) }
+        let(:min_flush_time) { 2 }
+        let(:compress_spooler_config) { { "spool_size" => spool_size, "min_flush_time" => min_flush_time } } 
+        subject(:codec) { LogStash::Codecs::CompressSpooler.new(compress_spooler_config) }
         let(:data) { {"foo" => "bar"} }
 
         it "dont'f flush the initial messages, but flush after min flush time on next message" do


### PR DESCRIPTION
Implements a naive aproach to allow a minimum flush interval (best effort).
The queue is flushed, when the next event is processed, after the minimum
flush interval is exeeded.

Fixes #9